### PR TITLE
Update namelist to use data rather than additional state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-final-form-arrays",
+  "name": "react-final-form-named-arrays",
   "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -9327,13 +9327,30 @@
       }
     },
     "react-final-form": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-6.3.0.tgz",
-      "integrity": "sha512-jijhXR1fFGUBQwNOSqF4MK8XJO7Ynl1p8vcFsnQS0INSkGI52+4IagjUgtHj3w8EviIHPFK/Eflji6FELUl07w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-6.4.0.tgz",
+      "integrity": "sha512-M7J7f0pnoj0o8sBq3iG6jsWJEh08pNUyl2D4wBC9SJvCNkGdol2UdyjMiEFYD3rz9LIFzQqFSG0kbRBCadqzhA==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "ts-essentials": "^2.0.8"
+        "@babel/runtime": "^7.9.2",
+        "ts-essentials": "^6.0.3"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.9.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+          "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+          "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+          "dev": true
+        }
       }
     },
     "react-is": {
@@ -10758,9 +10775,9 @@
       "dev": true
     },
     "ts-essentials": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
-      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-6.0.5.tgz",
+      "integrity": "sha512-RSAKlpu+E0DCGY8FsbG92EveRLw2Y+UgK3ksX01w1VaHeG01dKkYo/KtAV4q0qPT6nPbLfyerb2YPVSediP+8g==",
       "dev": true
     },
     "tslib": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-final-form-arrays",
+  "name": "react-final-form-named-arrays",
   "version": "3.1.1",
   "description": "A component for rendering and editing arrays 🏁 React Final Form",
   "main": "dist/react-final-form-arrays.cjs.js",

--- a/src/FieldArray.test.js
+++ b/src/FieldArray.test.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { render, fireEvent, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
-import arrayMutators from 'final-form-arrays'
+import arrayMutators from './nameListMutators'
+import { NAME_LIST_INITIALISED, NAME_LIST } from './nameListMutators/constants'
 import { ErrorBoundary, Toggle, wrapWith } from './testUtils'
 import { Form, Field } from 'react-final-form'
 import { FieldArray, version } from '.'
@@ -65,7 +66,7 @@ describe('FieldArray', () => {
     expect(errorSpy).toHaveBeenCalled()
     expect(errorSpy).toHaveBeenCalledTimes(1)
     expect(errorSpy.mock.calls[0][0].message).toBe(
-      'Array mutators not found. You need to provide the mutators from final-form-arrays to your form'
+      'Array mutators not found. You need to provide the mutators from react-final-form-named-arrays to your form'
     )
     console.error.mockRestore()
   })
@@ -813,13 +814,18 @@ describe('FieldArray', () => {
   //   expect(getByTestId('error')).toHaveTextContent('Too many')
   // })
 
-  it('should provide names === null if no getItemName is provided', () => {
+  it('data should not be effected if no getItemName is provided', () => {
     const renderArray = jest.fn(() => <div />)
     render(
       <Form
         onSubmit={onSubmitMock}
         mutators={arrayMutators}
-        subscription={{}}
+        subscription={{
+          value: true,
+          data: true,
+          pristine: true,
+          initial: true
+        }}
         initialValues={{ foo: ['a', 'b', 'c'] }}
       >
         {() => (
@@ -832,7 +838,7 @@ describe('FieldArray', () => {
     expect(renderArray).toHaveBeenCalled()
     expect(renderArray).toHaveBeenCalledTimes(1)
 
-    expect(renderArray.mock.calls[0][0].fields.names).toBe(null)
+    expect(renderArray.mock.calls[0][0].meta.data).toEqual({})
   })
 
   it('should provide names calculated from initialValues', () => {
@@ -841,7 +847,13 @@ describe('FieldArray', () => {
       <Form
         onSubmit={onSubmitMock}
         mutators={arrayMutators}
-        subscription={{}}
+        //getItemName={v => v}
+        subscription={{
+          data: true,
+          initial: true,
+          pristine: true,
+          value: true
+        }}
         initialValues={{ foo: ['a', 'b', 'c'] }}
       >
         {() => (
@@ -854,8 +866,11 @@ describe('FieldArray', () => {
       </Form>
     )
     expect(renderArray).toHaveBeenCalled()
-    expect(renderArray).toHaveBeenCalledTimes(1)
+    expect(renderArray).toHaveBeenCalledTimes(2)
 
-    expect(renderArray.mock.calls[0][0].fields.names).toEqual(['a', 'b', 'c'])
+    expect(renderArray.mock.calls[1][0].meta.data).toEqual({
+      [NAME_LIST_INITIALISED]: true,
+      [NAME_LIST]: ['a', 'b', 'c']
+    })
   })
 })

--- a/src/nameListMutators/constants.js
+++ b/src/nameListMutators/constants.js
@@ -1,0 +1,2 @@
+export const NAME_LIST: string = 'NAME_LIST'
+export const NAME_LIST_INITIALISED: string = 'NAME_LIST_INITIALISED'

--- a/src/nameListMutators/index.js
+++ b/src/nameListMutators/index.js
@@ -1,1 +1,15 @@
-export default {}
+import type { Mutator } from 'final-form'
+import arrayMutators from 'final-form-arrays'
+
+import setNameList from './setNameList'
+import setNameListInitialised from './setNameListInitialised'
+
+export const mutatorsUsingGetItemName: string[] = []
+
+const mutators: { [string]: Mutator<any> } = {
+  ...arrayMutators,
+  setNameList,
+  setNameListInitialised
+}
+
+export default mutators

--- a/src/nameListMutators/setNameList.js
+++ b/src/nameListMutators/setNameList.js
@@ -1,0 +1,14 @@
+import type { MutableState, Mutator, Tools } from 'final-form'
+import { NAME_LIST } from './constants'
+
+const setNameList: Mutator<any> = (
+  [name, value]: any[],
+  state: MutableState,
+  { setIn }: Tools<any>
+) => {
+  if (state.fields[name]) {
+    state.fields[name].data = setIn(state.fields[name].data, NAME_LIST, value)
+  }
+}
+
+export default setNameList

--- a/src/nameListMutators/setNameListInitialised.js
+++ b/src/nameListMutators/setNameListInitialised.js
@@ -1,0 +1,18 @@
+import type { MutableState, Mutator, Tools } from 'final-form'
+import { NAME_LIST_INITIALISED } from './constants'
+
+const setNameListInitialised: Mutator<any> = (
+  [name, value]: any[],
+  state: MutableState,
+  { setIn }: Tools<any>
+) => {
+  if (state.fields[name]) {
+    state.fields[name].data = setIn(
+      state.fields[name].data,
+      NAME_LIST_INITIALISED,
+      value
+    )
+  }
+}
+
+export default setNameListInitialised

--- a/src/types.js.flow
+++ b/src/types.js.flow
@@ -19,6 +19,7 @@ type Meta = $Shape<{
   submitting?: boolean,
   touched?: boolean,
   valid?: boolean,
+  validating?: boolean,
   visited?: boolean
 }>
 
@@ -29,7 +30,6 @@ export type FieldArrayRenderProps = {
     map: (iterator: (name: string, index: number) => any) => any[],
     move: (from: number, to: number) => void,
     name: string,
-    names: string[],
     pop: () => any,
     push: (value: any) => void,
     remove: (index: number) => any,

--- a/src/useFieldArray.js
+++ b/src/useFieldArray.js
@@ -4,7 +4,9 @@ import { useForm, useField } from 'react-final-form'
 import { fieldSubscriptionItems, ARRAY_ERROR } from 'final-form'
 import type { Mutators } from 'final-form-arrays'
 import type { FieldValidator, FieldSubscription } from 'final-form'
-import nameListMutators from './NameListMutators'
+
+import { mutatorsUsingGetItemName } from './nameListMutators'
+import { NAME_LIST_INITIALISED } from './nameListMutators/constants'
 import type { FieldArrayRenderProps, UseFieldArrayConfig } from './types'
 import defaultIsEqual from './defaultIsEqual'
 import useConstant from './useConstant'
@@ -26,6 +28,35 @@ const useFieldArray = (
   }: UseFieldArrayConfig = {}
 ): FieldArrayRenderProps => {
   const form = useForm('useFieldArray')
+
+  const formMutators: Mutators = form.mutators
+  const hasMutators = !!(
+    formMutators &&
+    formMutators.push &&
+    formMutators.pop &&
+    formMutators.setNameList &&
+    formMutators.setNameListInitialised
+  )
+  if (!hasMutators) {
+    throw new Error(
+      'Array mutators not found. You need to provide the mutators from react-final-form-named-arrays to your form'
+    )
+  }
+
+  const mutators = useConstant<Mutators>(() => {
+    // curry the field name onto all mutator calls
+    // and also getItemName if applicable
+    return Object.keys(formMutators).reduce((result, key) => {
+      if (getItemName && mutatorsUsingGetItemName.includes(key)) {
+        result[key] = (...args) => {
+          return formMutators[key](name, ...args, getItemName)
+        }
+      } else {
+        result[key] = (...args) => formMutators[key](name, ...args)
+      }
+      return result
+    }, {})
+  })
 
   const validate: FieldValidator = useConstant(
     () => (value, allValues, meta) => {
@@ -55,36 +86,51 @@ const useFieldArray = (
     format: v => v
   })
 
-  const [nameList, setNameList] = React.useState<null | string[]>(
-    meta.initial && getItemName
-      ? meta.initial.map(v => getItemName(v, meta.initial))
-      : null
-  )
-
-  const formMutators: Mutators = form.mutators
-  const hasMutators = !!(formMutators && formMutators.push && formMutators.pop)
-  if (!hasMutators) {
-    throw new Error(
-      'Array mutators not found. You need to provide the mutators from final-form-arrays to your form'
+  const reinitialiseNameList = initial_data => {
+    mutators.setNameList(
+      initial_data && getItemName
+        ? initial_data.map(value => getItemName(value, initial_data))
+        : []
     )
+    mutators.setNameListInitialised(true)
   }
 
-  const mutators = useConstant<Mutators>(() => {
-    // curry the field name onto all mutator calls
-    // and apply the nameListMutator if applicable
-    const nameListMutatorKeys = Object.keys(nameListMutators)
-    return Object.keys(formMutators).reduce((result, key) => {
-      if (getItemName && nameListMutatorKeys.includes(key)) {
-        result[key] = (...args) => {
-          nameListMutators[key](setNameList, getItemName, ...args)
-          return formMutators[key](name, ...args)
-        }
-      } else {
-        result[key] = (...args) => formMutators[key](name, ...args)
-      }
-      return result
-    }, {})
-  })
+  // set initial name list during first render
+  const firstRender = React.useRef(true)
+  React.useEffect(() => {
+    if (getItemName && meta.initial) {
+      reinitialiseNameList(meta.initial)
+      firstRender.current = false
+    }
+  }, [])
+
+  // reset name list when form is reset:
+  // Ideally we would use modified here rather than pristine, however
+  // there are two erros with modified at the time of writing, that would
+  // make this difficult:
+  // 1) https://github.com/final-form/final-form/issues/317
+  // 2) https://github.com/final-form/final-form-arrays/issues/53
+  if (
+    getItemName &&
+    !firstRender &&
+    meta.pristine &&
+    meta.data &&
+    !meta.data[NAME_LIST_INITIALISED]
+  ) {
+    // note that this will not
+    reinitialiseNameList()
+  }
+  // if the field is no longer prisitne, set NAME_LIST_INITIALISED variable
+  // to false so that if the field returns to pristine again, then the name
+  // list will be initialised.
+  if (
+    getItemName &&
+    meta.data &&
+    meta.data[NAME_LIST_INITIALISED] &&
+    !meta.pristine
+  ) {
+    mutators.setNameListInitialised(false)
+  }
 
   const forEach = (iterator: (name: string, index: number) => void): void => {
     // required || for Flow, but results in uncovered line in Jest/Istanbul
@@ -114,8 +160,7 @@ const useFieldArray = (
       map,
       ...mutators,
       ...fieldState,
-      value: input.value,
-      names: nameList
+      value: input.value
     },
     meta
   }

--- a/src/useFieldArray.test.js
+++ b/src/useFieldArray.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
-import arrayMutators from 'final-form-arrays'
+import arrayMutators from './nameListMutators'
 import { ErrorBoundary } from './testUtils'
 import { Form } from 'react-final-form'
 import useFieldArray from './useFieldArray'


### PR DESCRIPTION
Update name list to use data rather than additional state:
 - Add two new modifiers, setNameList and setNameListInitialised,
 - Update tests,
 - Ensure, reset behaviour works correctly